### PR TITLE
Refactor scenes

### DIFF
--- a/app/assets/javascripts/game/command_handler.js
+++ b/app/assets/javascripts/game/command_handler.js
@@ -29,6 +29,7 @@ function handle_command(data) {
 
     if (activePlayerCount === MAX_PLAYERS) {
       game.scene.switch('title', 'main');
+      game.scene.wake('main');
     }
   }
   else if (command == 'u') {

--- a/app/assets/javascripts/game/command_handler.js
+++ b/app/assets/javascripts/game/command_handler.js
@@ -18,8 +18,17 @@ function handle_command(data) {
   if (command == 'online') {
   }
   else if (command == 's') {
-    if (!Player.active_players[id]) {
+    // TODO: change this to 4 when we have multi-player working
+    const MAX_PLAYERS = 1
+    let activePlayerCount = Object.keys(Player.active_players).length
+
+    if (!Player.active_players[id] && activePlayerCount < MAX_PLAYERS) {
       App.cable.subscriptions.subscriptions[0].perform("register_player",  { id: id })
+      activePlayerCount++;
+    }
+
+    if (activePlayerCount === MAX_PLAYERS) {
+      game.scene.switch('title', 'main');
     }
   }
   else if (command == 'u') {

--- a/app/assets/javascripts/game/enemy.js
+++ b/app/assets/javascripts/game/enemy.js
@@ -4,14 +4,13 @@ function hit_enemy(player, enemy) {
 
 class Enemy {
   constructor(id) {
-    if (typeof(id) == "undefined") {
-      console.log("Revived " + id);
+    if (typeof(id) === "undefined") {
       this.id = "enemy" + (Object.keys(Enemy.active_enemies).length + 1)
-    } else if (id == null) {
+      console.log("New enemy id is " + this.id);
+    } else if (id === null) {
       return;
-    }
-    else {
-      console.log("New enemy id was " + id);
+    } else {
+      console.log("Revived " + id);
       this.id = id;
     }
 

--- a/app/assets/javascripts/game/init.js
+++ b/app/assets/javascripts/game/init.js
@@ -12,7 +12,7 @@ const gameConfig = {
       debug: false
     }
   },
-  scene: [TitleScene],
+  scene: [TitleScene, MainScene],
   audio: {
     disableWebAudio: true
   }

--- a/app/assets/javascripts/game/scenes/main.js
+++ b/app/assets/javascripts/game/scenes/main.js
@@ -1,24 +1,32 @@
-var frameNames;
-const MainScene = new Phaser.Class({
-  Extends: Phaser.Scene,
-  active: false,
-  initialize: function MainScene () {
-    Phaser.Scene.call(this, { key: 'main' });
-  },
+class MainScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'main', active: false });
+  }
 
-  preload: function () {
-    this.load.path = game.asset_path
+  preload() {
     scene = this;
-  },
 
-  create: function () {
+    this.load.path = game.asset_path
+    this.load.multiatlas('multipass');
+    this.load.tilemapTiledJSON('map', 'shapes.json');
+
     Player.load();
     Enemy.load();
 
+    add_keyboard_controls(this);
+  }
+
+  create() {
     let music = this.sound.add('theme');
     music.play();
-  },
-
-  update: function () {
   }
-});
+
+  update() {
+    if (scene.started && (scene.music.isPlaying == false)) {
+      scene.music.play();
+    };
+
+    Player.update();
+    Enemy.update();
+  }
+}

--- a/app/assets/javascripts/game/scenes/title.js
+++ b/app/assets/javascripts/game/scenes/title.js
@@ -10,44 +10,41 @@ function new_game() {
   );
 }
 
-const TitleScene = new Phaser.Class({
-  Extends: Phaser.Scene,
-  active: true,
-  initialize: function TitleScene () {
-    Phaser.Scene.call(this, { key: 'title' });
-  },
+class TitleScene extends Phaser.Scene {
+  constructor() {
+    super('title');
+  }
 
-  preload: function () {
-	scene = this;
+  preload() {
+    scene = this;
 
-	this.started = false;
+    this.started = false;
     this.load.path = game.asset_path;
     this.load.multiatlas('multipass');
     this.load.tilemapTiledJSON('map', 'shapes.json');
-
+  
     Player.load();
     Enemy.load();
-
+  
     TitleScene.start_x = screen.width / 2;
     TitleScene.start_y = screen.height / 3;
-
+  
     this.load.audio('theme', ['audio/neoishiki.mp3']);
 
-	add_keyboard_controls(this);
-
+    add_keyboard_controls(this);
+  
     let graphics = this.add.graphics();
-  },
+  }
 
-  create: function () {
+  create() {
     new_game();
 
-    title = this.add.sprite(
+    scene.title_sprite = this.add.sprite(
       TitleScene.start_x,
       TitleScene.start_y,
       'multipass',
       'start/title'
     );
-    scene.title_sprite = title;
 
     scene.music = this.sound.add('theme');
 
@@ -60,9 +57,9 @@ const TitleScene = new Phaser.Class({
       y: { getStart: scene.title_sprite.y, getEnd: scene.title_sprite.y },
       alpha: { getStart: 1, getEnd: 0 }
     });
-  },
+  }
 
-  update: function () {
+  update() {
     if (scene.started && (scene.music.isPlaying == false)) {
       scene.music.play();
     };
@@ -70,4 +67,4 @@ const TitleScene = new Phaser.Class({
     Player.update();
     Enemy.update();
   }
-});
+}

--- a/app/assets/javascripts/game/scenes/title.js
+++ b/app/assets/javascripts/game/scenes/title.js
@@ -47,16 +47,6 @@ class TitleScene extends Phaser.Scene {
     );
 
     scene.music = this.sound.add('theme');
-
-    scene.title_tween = scene.add.tween({
-      targets: [scene.title_sprite],
-      ease: 'Sine.easeInOut',
-      duration: 1000,
-      delay: 0,
-      x: { getStart: scene.title_sprite.x, getEnd: scene.title_sprite.x },
-      y: { getStart: scene.title_sprite.y, getEnd: scene.title_sprite.y },
-      alpha: { getStart: 1, getEnd: 0 }
-    });
   }
 
   update() {

--- a/app/assets/javascripts/game/scenes/title.js
+++ b/app/assets/javascripts/game/scenes/title.js
@@ -1,6 +1,3 @@
-const title_wiggle = 10;
-const title_speed = 3;
-
 function new_game() {
   App.cable.subscriptions.subscriptions[0].perform(
     "new_game",
@@ -24,7 +21,6 @@ class TitleScene extends Phaser.Scene {
     this.load.tilemapTiledJSON('map', 'shapes.json');
   
     Player.load();
-    Enemy.load();
   
     TitleScene.start_x = screen.width / 2;
     TitleScene.start_y = screen.height / 3;
@@ -55,6 +51,5 @@ class TitleScene extends Phaser.Scene {
     };
 
     Player.update();
-    Enemy.update();
   }
 }


### PR DESCRIPTION
This PR cleans up a few things:
- Refactor the scenes as ES6 classes
- Move game play functionality from title scene to main scene
- Fix some enemy spawning issues that came up due to moving game play functionality from the title scene to the main scene.
- Deletes some dead code.

Note that there is now a constant called `MAX_PLAYERS` in `command_handler.js` (see [here](https://github.com/thejonanshow/spaceblazer/compare/rails...refactor-scenes?expand=1#diff-b334afbfbc0c63833db038649da45febR22). This controls how many players can join the game before it starts. Players queue up on the left side of the title scene as they join. When `MAX_PLAYERS` have joined, the game starts. Until then, queued players can move their character around to get a feel for the controls before the game starts.

We should probably still add a 5, 4, 3, 2, 1 countdown scene between the title scene and main scene before game play starts so that the game start is not so abrupt and unexpected.