### PR TITLE
Less negative scores moar points

### DIFF
--- a/app/assets/javascripts/game/player.js
+++ b/app/assets/javascripts/game/player.js
@@ -139,7 +139,7 @@ class Player {
   bulletStrike(bullet, enemy) {
     enemy.wrapper.die();
     bullet.destroy();
-    this.incrementScore();
+    this.incrementScore(10);
   };
 
   // Increment score by amount or by 1 if amount not specified

--- a/app/assets/javascripts/game/player.js
+++ b/app/assets/javascripts/game/player.js
@@ -149,7 +149,7 @@ class Player {
 
   // Decrement score by amount or by 1 if amount not specified
   decrementScore(amount) {
-    this.updateScore(amount || -1);
+    this.updateScore(-1 * (amount || 1));
   }
 
   updateScore(amount) {

--- a/app/assets/javascripts/game/scenes/main.js
+++ b/app/assets/javascripts/game/scenes/main.js
@@ -76,7 +76,8 @@ class MainScene extends Phaser.Scene {
     this.waitingText = this.add.text(this.centerX, this.textY, '', { fontSize: '24px', fill: '#fff' });
     this.waitingText.originX = 0.5;
 
-    this.NUM_PLAYERS = spaceblazerConfig("minimum_players");
+    // this.NUM_PLAYERS = spaceblazerConfig("minimum_players");
+    this.NUM_PLAYERS = 1;
   }
 
   update() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.12.0.tgz",
       "integrity": "sha512-3f4xFi+upHtQpM6GyZHoDKR6iq8Ubyr+3g1pmBrq5qovvV2deSUjGkuF9LP793TYS/WFMrZ0Yi3kkPLKIF3Kaw==",
       "requires": {
-        "eventemitter3": "3.1.0"
+        "eventemitter3": "^3.1.0"
       }
     }
   }


### PR DESCRIPTION
Based on user feedback, players get 10 points for hitting an enemy with a rainbow ball.

People I tested the game with (and also me) were ending up with negative or close to zero scores. It is hard to not get hit by a floppy or a server! Negative scores for most of the players sucks. To offset that, let's give the player more points when they hit an enemy with a rainbow ball.